### PR TITLE
jun20-2025

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -6,15 +6,11 @@ title: Hi, I'm Ernest!
 | :---------------: | :-----------------------------: | :----------------: | :-------------: | :---------------: | :-------------------: |
 | ![[BRP.png\|100]] | ![[Cropped_Image (2).png\|100]] | ![[bike.png\|100]] | ![[U.png\|100]] | ![[run.png\|100]] | ![[rainbow.png\|100]] |
 
-Incoming @ Tesla for Dojo supercomputer hardware
+prev Tesla working on Dojo supercomputer hardware
 
-Working on a budget-friendly mini humanoid robotics platform with [[UW RoboSoccer]]
+Working on a budget-friendly mini humanoid robotics platform
 
-Previously firmware @ [Geotab](https://www.geotab.com/), product development for SxS Vehicles@ [BRP](https://www.brp.com/en/), mechatronics @ Paragon Systems
-
-Follow my [Strava](https://strava.app.link/0cGqWokPRHb) and [Spotify](https://open.spotify.com/user/ernestwang135791?si=eb867f3241e14a72)!
-
-[[cool things i've read or saw]]
+Follow me on [Strava](https://strava.app.link/0cGqWokPRHb) and [Spotify](https://open.spotify.com/user/ernestwang135791?si=eb867f3241e14a72)
 
 
 ###### Projects:
@@ -22,6 +18,6 @@ Follow my [Strava](https://strava.app.link/0cGqWokPRHb) and [Spotify](https://op
 |                                                                            |                                                                                                 |                                                                                                         |
 | :------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------: |
 |  [![[robosoccer.png\|200]]](https://ernestwang.ca/Projects/UW-RoboSoccer)  | [![[image-removebg-preview (2) 1.png\|200]]](https://ernestwang.ca/Projects/Wheel-legged-Robot) | [![[Pasted image 20241129143709.png\|200]]](https://ernestwang.ca/Projects/U-Robotic-Arm/U-Robotic-Arm) |
-|                     *UW RoboSoccer: progress tracking*                     |                            *Wheeled-Legged Robot: moving & jumping*                             |                                   *Robotic Arm: capable of 2kg load*                                    |
+|                     *mini humanoid*                     |                            *Wheeled-Legged*                             |                                   *Robotic Arm*                                    |
 | [![[harmonic.png\|200]]](https://ernestwang.ca/Projects/Harmonic-Actuator) |                         ![[Screenshot 2024-12-13 at 12.12.12.png\|200]]                         |                                     ![[Cropped_Image (3).png\|200]]                                     |
-|                        3D printed harmonic actuator                        |                                        Work in progress                                         |                                          just a cool photo :)                                           |
+|                        3D printed harmonic actuator                        |                                        Work in progress                                         |                                          :)                                           |


### PR DESCRIPTION
## Summary by Sourcery

Revise personal portfolio markdown to update the profile bio and streamline project descriptions

Documentation:
- Update profile header to indicate a past Tesla role and remove the UW RoboSoccer link
- Remove legacy roles at Geotab, BRP, and Paragon Systems from the bio
- Adjust follow links phrasing to “Follow me on Strava and Spotify”
- Simplify project captions by removing progress details and extra annotations
- Remove extraneous status notes and icons from project entries